### PR TITLE
Slightly clearer build instructions in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,21 @@
-# Created by .ignore support plugin (hsz.mobi)
-### SBT template
-# Simple Build Tool
-# http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control
-
-dist/
+*~
+*\.ZILESAVE
+*\.tmp
+*\.log
+*\.out
+/\.classpath
+/\.project
+/\.settings
+/\.idea
+/\.idea_modules
+/\.lib
+*\.iml
+\.classpath_nb
+\.ensime
+\.ensime_lucene
+\.ensime_cache/
 target/
+dist/
 lib_managed/
 src_managed/
 project/boot/
@@ -12,7 +23,7 @@ project/plugins/project/
 .history
 .cache
 .lib/
-
 .idea/
-logs
-
+logs/
+lib/
+tmp/

--- a/README.md
+++ b/README.md
@@ -16,24 +16,55 @@ Under the hood it uses:
 
 ### Prerequisites
 
-- Node installed on the dev box
-- SBT installed on the dev box
-- Follow the instructions in the file `project/WebClient.scala`
-- If an error at build time appears saying that module `style-loader` cannot be found, run `npm install -g style-loader css-loader`
+1. Docker installed on the dev box.
+   See: [https://github.com/frgomes/bash-scripts/blob/master/sysadmin-install/install-docker-ce.sh](https://github.com/frgomes/bash-scripts/blob/master/sysadmin-install/install-docker-ce.sh) 
 
-## Setup
+2. Node installed on the dev box.
+  See: [http://github.com/frgomes/bash-scripts/blob/master/user-install/install-node.sh](http://github.com/frgomes/bash-scripts/blob/master/user-install/install-node.sh) 
+
+3. SBT installed on the dev box
+  See: [https://github.com/frgomes/bash-scripts/blob/master/user-install/install-scala.sh](https://github.com/frgomes/bash-scripts/blob/master/user-install/install-scala.sh) 
+
+4. Follow the instructions in the file `project/WebClient.scala`.
+
+5. If an error at build time appears saying that module `style-loader` cannot be found, run `npm install -g style-loader css-loader`
+
+### IDE support
 Follow the setup [here](https://slinky.shadaj.me/docs/installation/) for IntelliJ support.
 
-The project needs a mysql database to work, if you are using docker you can run the following command to start it:
-```
-docker run --name=test_db_server -e 'MYSQL_ROOT_PASSWORD=root' -e 'MYSQL_ROOT_HOST=%' -e 'MYSQL_DATABASE=test' -p 3306:3306 -d mysql/mysql-server:5.7.19
+### Build instructions
+
+* Make sure you have already built and published locally ``apollo-scalajs`` according to instructions at `project/WebClient.scala`.
+
+* Start a MySQL container via Docker Compose.
+```bash
+$ docker-compose up -d
 ```
 
-## Commands
+**Note**: Only MySQL is supported at the moment. In order to support other databases, we should have multiple sets of DDLs and evolutions per database vendor.
 
-- _run_: runs the server and live reloads the changes
-- _web_client/Compile/managedSources_: generates schema.graphql and query/mutation objects for the client (you shouldn't need to use this explicitly)
-- _assembly_: generates the uber jar 
+* Run test cases:
+```bash
+$ sbt clean test
+```
+
+* Runs the server and live reloads changes:
+```
+$ sbt run
+```
+
+* Generates a fat jar:
+```
+$ sbt assembly
+```
+
+## Code generation
+
+Generates schema.graphql and query/mutation objects for the client.
+You shouldn't need to use this explicitly.
+```
+$ sbt web_client/Compile/managedSources
+```
 
 ## Usage
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: '3'
+services:
+
+#  postgres:
+#    image: postgres:11.3
+#    restart: always
+#    environment:
+#      POSTGRES_USER: admin
+#      POSTGRES_PASSWORD: admin
+#    ports:
+#      - 5432:5432
+#    volumes:
+#      - postgres:/var/lib/postgresql/data
+
+  mysql:
+    image: mysql:5.7.26
+    environment:
+      MYSQL_DATABASE: test
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: admin
+      MYSQL_PASSWORD: admin
+    ports:
+      - 3306:3306
+    volumes:
+      - mysql:/var/lib/mysql
+    restart: always
+
+volumes:
+  postgres: ~
+  mysql: ~

--- a/project/Server.scala
+++ b/project/Server.scala
@@ -33,6 +33,7 @@ object Server {
       "com.typesafe.slick" %% "slick" % slickV,
       "com.typesafe.slick" %% "slick-codegen" % slickV,
       "mysql" % "mysql-connector-java" % "6.0.6",
+      "org.postgresql" % "postgresql" % "42.2.5",
       "com.mohiva" %% "play-silhouette" % silhouetteV,
       "com.mohiva" %% "play-silhouette-password-bcrypt" % silhouetteV,
       "com.mohiva" %% "play-silhouette-crypto-jca" % silhouetteV,

--- a/project/WebClient.scala
+++ b/project/WebClient.scala
@@ -13,24 +13,26 @@ object WebClient {
   val reactVer = "16.5.2"
   
   /* 
-   * This version is not available yet, the changes needed to make this project work are in the master but still
-   * need to be released.
+   * Some dependencies needed to make this project work are in the master branch, still to be released.
    * 
-   * In order to make this work, follow these steps: 
-   * 1. clone the repo https://github.com/apollographql/apollo-scalajs
-   * 2. change the file "build.sbt" adding at its top the lines (backtick not included):
-   *     ```
-   *     version in ThisBuild := "0.7.1-SNAPSHOT"
+   * In order to make this project work, follow these steps: 
    *
-   *     dynver in ThisBuild := "0.7.1-SNAPSHOT"
-   * 
+   * 1. Clone the repo https://github.com/frgomes/apollo-scalajs
    *     ```
-   * 3. run the command (backtick not included):
+   *     $ git clone https://github.com/frgomes/apollo-scalajs
    *     ```
-   *     sbt publishLocal
+   * 2. Run SBT, publishLocal and obtain the published version information:
    *     ```
+   *     $ cd apollo-scalajs
+   *     $ sbt
+   *     > publishLocal
+   *     > show core/version
+   *     0.7.0+26-5cd49197+20190616-1445
+   *     > quit
+   *     ```
+   * 3. update variable ``apolloScalaJsVer`` so that it contains the version information just obtained.
    */
-  val apolloScalaJsVer = "0.7.1-SNAPSHOT"
+  val apolloScalaJsVer = "0.7.0+27-0badbdb2"
 
 
   private[this] val clientSettings = 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -16,17 +16,34 @@ play.filters.disabled += "play.filters.csrf.CSRFFilter"
 // Dependency Injection module
 play.modules.enabled += "di.DiModule"
 
-slick.dbs.default {
-  profile="slick.jdbc.MySQLProfile$"
-  db {
-    databaseName = "test"
-    driver="com.mysql.cj.jdbc.Driver"
-    url = "jdbc:mysql://localhost/test?nullNamePatternMatchesAll=true&useSSL=false"
-    user = "root"
-    password = "root"
+slick.dbs {
+  postgres {
+    profile="slick.jdbc.PostgresProfile$"
+    db {
+      driver = "org.postgresql.Driver"
+      url = "jdbc:postgresql://localhost:5432/test"
+      databaseName = "test"
+      user = "admin"
+      password = "admin"
+    }
+    codegen {
+      package = "database"
+      outputDir = "slick"
+    }
   }
-  codegen {
-    package = "database"
-    outputDir = "slick"
+  mysql {
+    profile="slick.jdbc.MySQLProfile$"
+    db {
+      driver="com.mysql.cj.jdbc.Driver"
+      url = "jdbc:mysql://localhost/test?nullNamePatternMatchesAll=true&useSSL=false"
+      databaseName = "test"
+      user = "admin"
+      password = "admin"
+    }
+    codegen {
+      package = "database"
+      outputDir = "slick"
+    }
   }
+  default = ${slick.dbs.mysql}
 }


### PR DESCRIPTION
The aim is providing a slightly more convenient environment for development.

* A ``docker-compose.yaml`` file which automagically brings up a MySQL database.

* I've pushed some improvements to ``apollo-scalajs`` which makes life a bit easier, since there's no need anymore to download and change locally project ``apollo-scalajs``. See:
https://github.com/apollographql/apollo-scalajs/pull/43

* The documentation in README.md was reviewed accordingly.

